### PR TITLE
start Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.7
+LABEL maintainer="Strubbl <Strubbl-Dockerfile@linux4tw.de>"
+
+ENV RUNNER_DIR /home/runner
+RUN \
+  useradd runner && \
+  mkdir -p ${RUNNER_DIR} && \
+  chown -R runner:runner ${RUNNER_DIR}
+WORKDIR ${RUNNER_DIR}
+USER runner
+RUN \
+  wget https://raw.githubusercontent.com/jedie/django-for-runners/master/boot_django_for_runners.sh && \
+  bash boot_django_for_runners.sh && \
+  cd ${RUNNER_DIR}/Django-ForRunners/bin && \
+  ./manage collectstatic
+
+EXPOSE 8000
+
+CMD cd ${RUNNER_DIR}/Django-ForRunners/bin && ./for_runners run-server 0.0.0.0:8000


### PR DESCRIPTION
This commit starts a Dockerfile. With the following commands i build the
container, run the web server and create a user for the app:

```
$ docker build --pull -t docker_djangorunners .
$ docker run -it -p 8055:8000 docker_djangorunners
$ docker ps
CONTAINER ID        IMAGE                  COMMAND                  CREATED             STATUS              PORTS                                            NAMES
613fbb0c9218        docker_djangorunners   "/bin/sh -c 'cd ${RU…"   9 seconds ago       Up 7 seconds        0.0.0.0:8055->8000/tcp                           friendly_lehmann
$ docker exec -it 613fbb0c9218 ./Django-ForRunners/bin/manage createsuperuser
Django-ForRunners v0.10.0
Use settings: /home/runner/Django-ForRunners/src/django-for-runners/for_runners_project/settings.py
Use Database: '/home/runner/Django-ForRunners/Django-ForRunners-database.sqlite3'
Tracks stored in '/home/runner/Django-ForRunners/media'
Username (leave blank to use 'runner'):
…
```